### PR TITLE
Simplify error handling in execution

### DIFF
--- a/includes/error.h
+++ b/includes/error.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   error.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tchoquet <tchoquet@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/12 18:31:32 by tchoquet          #+#    #+#             */
-/*   Updated: 2023/08/17 15:52:52 by tchoquet         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:53:32 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,5 @@ int		print_error_msg(char *msg, int return_val);
 int		print_error(int code);
 int		printf_error_msg(char *format, char *data[], int return_val);
 int		perror_wrap(char *msg, int val);
-int		exec_error(char *cmd, int flag, char *msg);
 
 #endif // ERROR_H

--- a/sources/error.c
+++ b/sources/error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   error.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tchoquet <tchoquet@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/12 18:32:01 by tchoquet          #+#    #+#             */
-/*   Updated: 2023/08/17 15:53:59 by tchoquet         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:53:38 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,24 +64,4 @@ int	perror_wrap(char *msg, int val)
 {
 	perror(msg);
 	return (val);
-}
-
-int	exec_error(char *cmd, int flag, char *msg)
-{
-	char	*tmp;
-
-	ft_putstr_fd("minishell: ", 2);
-	if (msg == NULL)
-	{
-		perror_wrap(cmd, flag);
-		return (flag);
-	}
-	else
-	{
-		ft_putstr_fd(cmd, 2);
-		ft_putstr_fd(": ", 2);
-		ft_putendl_fd(msg, 2);
-		return (flag);
-	}
-	return (flag);
 }

--- a/sources/exec_do.c
+++ b/sources/exec_do.c
@@ -6,7 +6,7 @@
 /*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/30 13:32:49 by sotanaka          #+#    #+#             */
-/*   Updated: 2023/08/17 16:12:49 by sotanaka         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:54:22 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,11 @@ static int	do_cmd(char *cmd_path, char **cmd_opts, char **envp)
 	{
 		free_splited_str(envp);
 		if (errno == EISDIR)
-			return (exec_error(cmd_path, IS_A_DIRECTORY, NULL));
+			return (printf_error_msg("minishell: %: %",
+					(char *[2]){cmd_path, strerror(errno)}, IS_A_DIRECTORY));
 		else
-			perror("minishell");
+			printf_error_msg("minishell: %: %",
+				(char *[2]){cmd_path, strerror(errno)}, 0);
 	}
 	return (1);
 }
@@ -92,7 +94,7 @@ int	exec_do(t_dexec *dexec, t_ast *node, int flag)
 {
 	int		pid;
 	int		status;
-	
+
 	pid = 0;
 	status = 0;
 	if (dexec->flag_builtin > 0)

--- a/sources/exec_prog.c
+++ b/sources/exec_prog.c
@@ -6,7 +6,7 @@
 /*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/13 15:01:43 by hotph             #+#    #+#             */
-/*   Updated: 2023/08/17 17:57:01 by sotanaka         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:41:22 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,20 +66,17 @@ static int	get_fullpath(char *path, char *prog, t_dexec *dexec)
 	if (status == 0)
 		return (status);
 	else if (path != NULL)
-	{
 		status = joint_path(path, prog, dexec);
-		if (status != 0)
-			return (status);
-	}
 	else
 	{
 		status = path_is_envp(prog, dexec);
 		free_splited_str(dexec->matrix_envpath);
 		if (status == CMD_NOTFOUND)
-			return (exec_error(prog, CMD_NOTFOUND, "command not found"));
-		if (status == 1)
-			return (status);
+			printf_error_msg("minishell: %: command not found",
+				&prog, CMD_NOTFOUND);
 	}
+	if (status != 0)
+		return (status);
 	status = check_cmdpath_hub(dexec, prog);
 	if (status != 0)
 		free_null((void **)&(dexec->cmd_path));

--- a/sources/exec_prog_utils1.c
+++ b/sources/exec_prog_utils1.c
@@ -6,7 +6,7 @@
 /*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 14:50:40 by sotanaka          #+#    #+#             */
-/*   Updated: 2023/08/17 18:40:07 by sotanaka         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:54:48 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,14 +82,17 @@ int	directory_is(char *path)
 	if (cpy == NULL)
 		return (print_error(MALLOC_ERROR));
 	path[ft_strlen(path) - 1] = '\0';
-	if (ft_stat_wrap(path, STAT_ISDIR) == true)
-		status = exec_error(cpy, CMD_CANT_EXEC, "Is a directory");
+	if (check_cmdpath(path, ACCESS_FOK) == 1)
+		status = printf_error_msg("minishell: %: %",
+				(char *[2]){cpy, strerror(errno)}, CMD_NOTFOUND);
+	else if (ft_stat_wrap(path, STAT_ISDIR) == true)
+		status = printf_error_msg("minishell: %: %",
+				(char *[2]){cpy, "Is a directory"}, CMD_CANT_EXEC);
 	else if (ft_stat_wrap(path, STAT_ISREG) == true)
-		status = exec_error(cpy, CMD_CANT_EXEC, "Not a directory");
+		status = printf_error_msg("minishell: %: %",
+				(char *[2]){cpy, "Not a directory"}, CMD_CANT_EXEC);
 	else if (ft_stat_wrap(path, 0) == 255)
 		status = 255;
-	else if (check_cmdpath(path, ACCESS_FOK) == 1)
-		status = exec_error(cpy, CMD_NOTFOUND, NULL);
 	free(cpy);
 	return (status);
 }

--- a/sources/exec_prog_utils2.c
+++ b/sources/exec_prog_utils2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_prog_utils2.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hotph <hotph@student.42.fr>                +#+  +:+       +#+        */
+/*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/04 17:42:46 by sotanaka          #+#    #+#             */
-/*   Updated: 2023/08/14 12:10:26 by hotph            ###   ########.fr       */
+/*   Updated: 2023/08/17 19:49:33 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,8 @@ int	check_cmdpath(char *cmd_path, int flag)
 	{
 		err = ft_access_wrap(cmd_path, ACCESS_FOK);
 		if (err == false)
-			exec_error(cmd_path, CMD_SIMPLE, NULL);
+			printf_error_msg("minishell: %: %",
+				(char *[2]){cmd_path, strerror(errno)}, CMD_SIMPLE);
 		else
 			return (0);
 	}
@@ -85,16 +86,13 @@ int	check_cmdpath(char *cmd_path, int flag)
 int	check_cmdpath_hub(t_dexec *dexec, char *prog)
 {
 	if (check_cmdpath(dexec->cmd_path, ACCESS_FOK) == 1)
-	{
-		return (exec_error(dexec->cmd_path, CMD_NOTFOUND, "command not found"));
-	}
+		return (printf_error_msg("minishell: %: No such file or directory",
+				&dexec->cmd_path, CMD_NOTFOUND));
 	if (ft_stat_wrap(dexec->cmd_path, STAT_ISDIR) == true)
-	{
-		return (exec_error(dexec->cmd_path, CMD_CANT_EXEC, "Is a directory"));
-	}
+		return (printf_error_msg("minishell: %: Is a directory",
+				&dexec->cmd_path, CMD_CANT_EXEC));
 	if (check_cmdpath(dexec->cmd_path, ACCESS_XOK) == 1)
-	{
-		return (exec_error(dexec->cmd_path, CMD_CANT_EXEC, NULL));
-	}
+		return (printf_error_msg("minishell: %: %",
+				(char *[2]){dexec->cmd_path, strerror(errno)}, CMD_CANT_EXEC));
 	return (0);
 }

--- a/sources/exec_redirect.c
+++ b/sources/exec_redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_redirect.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tchoquet <tchoquet@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: sotanaka <sotanaka@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/13 12:21:58 by hotph             #+#    #+#             */
-/*   Updated: 2023/08/17 16:11:16 by tchoquet         ###   ########.fr       */
+/*   Updated: 2023/08/17 19:55:01 by sotanaka         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,7 +81,8 @@ static int	ft_open_file(char *file_redirect, int flag_redirect, int *fd_io)
 	else
 		fd = open(file_redirect, O_RDONLY);
 	if (fd == -1)
-		return (exec_error(file_redirect, EX_FILE_OPEN_ERR, NULL));
+		return (printf_error_msg("minishell: %: %",
+				(char *[2]){file_redirect, strerror(errno)}, EX_FILE_OPEN_ERR));
 	else
 	{
 		if (*fd_io != fd && *fd_io != STDIN_FILENO && *fd_io != STDOUT_FILENO)


### PR DESCRIPTION
Fixes #43
- delete [exec_error] function. Merge to [printf_error_msg].
And additional
- some "if" priority for detect error was changed, to fit bash.